### PR TITLE
Caching of the MetaTrackable Object

### DIFF
--- a/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/Communicate.java
+++ b/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/Communicate.java
@@ -35,14 +35,23 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import io.realm.Realm;
+import io.realm.RealmQuery;
+import io.realm.RealmResults;
+
 
 /**
  * Contains methods used for communicating with the API.
  */
 public class Communicate {
-
+    private static final String DEBUG_KEY = "Communi";
+    private static final long DEFAULT_DB_CACHE_EXPIRE_TIME = 1209600000;    // 14 days.. If items are
+                                                                            // older than this they will be
+                                                                            // removed from the db and
+                                                                            // refreshed from the api.
 
     private Context context;
+    private Realm mRealm;
 
     /**
      * Create a communication's class.
@@ -50,6 +59,7 @@ public class Communicate {
      */
     public Communicate(Context context) {
         this.context = context;
+        this.mRealm = Realm.getInstance(context);
     }
 
     /**
@@ -489,32 +499,66 @@ public class Communicate {
         QueueProvider.getQueue(context).add(jsonObjectExtraRequest);
     }
 
-
+    /**
+     * Get a collection of MetaTrackables from the collection of id's provided. MetaTrackables are
+     * cached and if ALL ids are stored in the DB then the cache will be used, otherwise a new query
+     * will be made.
+     * @param type The trackable types for all ID's given.
+     * @param ids The ids for the MetaTrackables.
+     * @param apiResponse Response or error callback.
+     */
     public void getTrackable(final TrackableType type, List<Integer> ids, final APIResponse<ArrayList<MetaTrackable>, Error> apiResponse) {
-        String url = EndPointUrl.getAPIUrl(type.name().toLowerCase() + "s");
-        url += "?";
-        for (Integer id : ids) {
-            url += "ids[]=" + id + "&";
+        MetaTrackable.clearExpiredItems(mRealm, DEFAULT_DB_CACHE_EXPIRE_TIME);
+
+        RealmQuery<MetaTrackable> inDBQuery = mRealm.where(MetaTrackable.class);
+        boolean first = true;
+        for(Integer id : ids) {
+            if(!first)
+                inDBQuery.or();
+            else first = false;
+
+            inDBQuery.equalTo("id", id);
         }
-        JsonObjectExtraRequest jsonObjectExtraRequest = JsonObjectExtraRequest.createRequest(context, Request.Method.GET, url, new Response.Listener<JSONObject>() {
-            @Override
-            public void onResponse(JSONObject response) {
-                try {
-                    ArrayList<MetaTrackable> result = new ArrayList<>();
-                    JSONArray jArray = response.getJSONArray(type.name().toLowerCase() + "s");
-                    for (int i = 0; i < jArray.length(); i++) {
-                        result.add(new MetaTrackable(jArray.getJSONObject(i)));
+
+        inDBQuery = inDBQuery.findAll().where().equalTo("typeRaw", type.name());
+
+        if(inDBQuery.count() == ids.size()) { // No need to do query.
+            PreferenceKeys.log(PreferenceKeys.LOG_I, DEBUG_KEY, "Fetching Cached Meta Trackables");
+            RealmResults<MetaTrackable> inDBResults = inDBQuery.findAll();
+            apiResponse.onSuccess(new ArrayList<>(inDBResults.subList(0, inDBResults.size())));
+        } else {
+
+            String url = EndPointUrl.getAPIUrl(type.name().toLowerCase() + "s");
+            url += "?";
+            for (Integer id : ids) {
+                url += "ids[]=" + id + "&";
+            }
+            JsonObjectExtraRequest jsonObjectExtraRequest = JsonObjectExtraRequest.createRequest(context, Request.Method.GET, url, new Response.Listener<JSONObject>() {
+                @Override
+                public void onResponse(JSONObject response) {
+                    PreferenceKeys.log(PreferenceKeys.LOG_I, DEBUG_KEY, "Fetching Meta Trackables");
+                    try {
+                        ArrayList<MetaTrackable> result = new ArrayList<>();
+                        JSONArray jArray = response.getJSONArray(type.name().toLowerCase() + "s");
+                        for (int i = 0; i < jArray.length(); i++) {
+                            MetaTrackable mt = new MetaTrackable(jArray.getJSONObject(i));
+                            mt.setCachedAt(Calendar.getInstance()); // Set the cached time, enabling the db to stay fresh.
+                            result.add(mt);
+                        }
+                        mRealm.beginTransaction();
+                        mRealm.copyToRealmOrUpdate(result);
+                        mRealm.commitTransaction();
+                        apiResponse.onSuccess(result);
+                    } catch (JSONException e) {
+                        apiResponse.onFailure(new Error().setExceptionThrown(e).setDebugString("APIv2.Communicate.getTrackable:JSONException"));
                     }
-                    apiResponse.onSuccess(result);
-                } catch (JSONException e) {
-                    apiResponse.onFailure(new Error().setExceptionThrown(e).setDebugString("APIv2.Communicate.getTrackable:JSONException"));
                 }
-            }
-        }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-            }
-        });
-        QueueProvider.getQueue(context).add(jsonObjectExtraRequest);
+            }, new Response.ErrorListener() {
+                @Override
+                public void onErrorResponse(VolleyError error) {
+                }
+            });
+            QueueProvider.getQueue(context).add(jsonObjectExtraRequest);
+        }
     }
 }

--- a/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/MetaTrackable.java
+++ b/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/MetaTrackable.java
@@ -8,40 +8,70 @@ import org.json.JSONObject;
 import java.io.Serializable;
 import java.util.Calendar;
 
+import io.intercom.com.google.gson.annotations.SerializedName;
+import io.realm.RealmObject;
+import io.realm.annotations.Ignore;
+
 /**
  * Provides extra information about a trackable.
  */
-public class MetaTrackable implements Serializable {
-    private int colorId;
-    private int id;
+public class MetaTrackable extends RealmObject implements Serializable {
+    private Integer colorId;
+    private Integer id;
     private String name;
-    private TrackableType type;
-    private Calendar createdAt;
-    private Calendar updatedAt;
+
+    @Ignore
+    private transient TrackableType type; // Work around for Realm not being able to store the Calendar object.
+
+    @SerializedName("type")
+    private String typeRaw;
+
+    @Ignore
+    private transient Calendar createdAt; // Work around for Realm not being able to store the Calendar object.
+
+    @SerializedName("createdAt")
+    private Long createdAtRaw;
+
+    @Ignore
+    private transient Calendar updatedAt; // Work around for Realm not being able to store the Calendar object.
+
+    @SerializedName("updatedAt")
+    private Long updatedAtRaw;
+
+    @Ignore
+    private transient Calendar cachedAt; // Work around for Realm not being able to store the Calendar object.
+
+    @SerializedName("cachedAt")
+    private Long cachedAtRaw;
+
+    public MetaTrackable() {
+        this.colorId = 1;
+        this.id = 0;
+    }
 
 
     public MetaTrackable(JSONObject jObject) throws JSONException{
         this.colorId = jObject.optInt("color_id", 1);
         this.id = jObject.getInt("id");
         this.name = jObject.getString("name");
-        this.type = TrackableType.valueOfs(jObject.getString("type"));
-        this.createdAt = Date.stringToCalendar(jObject.optString("created_at", null));
-        this.updatedAt = Date.stringToCalendar(jObject.optString("updated_at", null));
+        setType(TrackableType.valueOfs(jObject.getString("type")));
+        this.createdAtRaw = Date.stringToMillis(jObject.optString("created_at", null));
+        this.updatedAtRaw = Date.stringToMillis(jObject.optString("updated_at", null));
     }
 
-    public int getColorId() {
+    public Integer getColorId() {
         return colorId;
     }
 
-    public void setColorId(int colorId) {
+    public void setColorId(Integer colorId) {
         this.colorId = colorId;
     }
 
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -54,26 +84,74 @@ public class MetaTrackable implements Serializable {
     }
 
     public TrackableType getType() {
-        return type;
+        return TrackableType.valueOf(getTypeRaw());
     }
 
     public void setType(TrackableType type) {
-        this.type = type;
+        setTypeRaw(type.name());
+    }
+
+    public String getTypeRaw() {
+        return typeRaw;
+    }
+
+    public void setTypeRaw(String type) {
+        typeRaw = type;
     }
 
     public Calendar getCreatedAt() {
-        return createdAt;
+        return Date.millisToCalendar(getCreatedAtRaw());
     }
 
     public void setCreatedAt(Calendar createdAt) {
-        this.createdAt = createdAt;
+        setCreatedAtRaw(createdAt.getTimeInMillis());
+    }
+
+    public Long getCreatedAtRaw() {
+        return createdAtRaw;
+    }
+
+    public void setCreatedAtRaw(Long createdAtRaw) {
+        this.createdAtRaw = createdAtRaw;
     }
 
     public Calendar getUpdatedAt() {
-        return updatedAt;
+        return Date.millisToCalendar(getUpdatedAtRaw());
     }
 
     public void setUpdatedAt(Calendar updatedAt) {
-        this.updatedAt = updatedAt;
+        setUpdatedAtRaw(updatedAt.getTimeInMillis());
+    }
+
+    public Long getUpdatedAtRaw() {
+        return updatedAtRaw;
+    }
+
+    public void setUpdatedAtRaw(Long updatedAtRaw) {
+        this.updatedAtRaw = updatedAtRaw;
+    }
+
+    /**
+     * Get the time when object stored in DB for caching.
+     * @return The time when the object was stored in the DB for caching.
+     */
+    public Calendar getCachedAt() {
+        return Date.millisToCalendar(getCachedAtRaw());
+    }
+
+    /**
+     * Set the time when the object is stored in the DB for caching.
+     * @param cachedAt The time when the object
+     */
+    public void setCachedAt(Calendar cachedAt) {
+        setCachedAtRaw(cachedAt.getTimeInMillis());
+    }
+
+    public Long getCachedAtRaw() {
+        return cachedAtRaw;
+    }
+
+    public void setCachedAtRaw(Long cachedAtRaw) {
+        this.cachedAtRaw = cachedAtRaw;
     }
 }

--- a/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/Trackable.java
+++ b/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/Trackable.java
@@ -5,8 +5,13 @@ import com.flaredown.flaredownApp.Helpers.APIv2.Helper.Date;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Used as a base to represent the trackables (Symptoms, Conditions & Treatments).
@@ -20,7 +25,7 @@ public class Trackable implements Serializable {
     private Integer value;
     private Integer trackableId;
     private String colourId;
-    private MetaTrackable metaTrackable = null;
+    private transient MetaTrackable metaTrackable = null;
 
     /**
      * Default constructor for the trackable object.
@@ -148,5 +153,42 @@ public class Trackable implements Serializable {
 
     public void setMetaTrackable(MetaTrackable metaTrackable) {
         this.metaTrackable = metaTrackable;
+    }
+
+    private final static String MT_ID = "mt_id";
+    private final static String MT_NAME = "mt_name";
+    private final static String MT_TYPE = "mt_type";
+    private final static String MT_CREATED_AT = "mt_createdAt";
+    private final static String MT_UPDATED_AT = "mt_updatedAt";
+    private final static String MT_CACHED_AT = "mt_cachedAt";
+
+    private void writeObject(ObjectOutputStream oos) throws IOException {
+        // Default serialzation.
+        oos.defaultWriteObject();
+
+        Map<String, Object> data = new HashMap<>();
+        data.put(MT_ID, metaTrackable.getId());
+        data.put(MT_NAME, metaTrackable.getName());
+        data.put(MT_TYPE, metaTrackable.getTypeRaw());
+        data.put(MT_CREATED_AT, metaTrackable.getCreatedAtRaw());
+        data.put(MT_UPDATED_AT, metaTrackable.getUpdatedAtRaw());
+        data.put(MT_CACHED_AT, metaTrackable.getCachedAtRaw());
+        oos.writeObject(data);
+    }
+
+    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
+        // Default deserializarion.
+        ois.defaultReadObject();
+
+        Map<String, Object> data = (HashMap<String, Object>) ois.readObject();
+        if(data.containsKey(MT_ID)) {
+            if(metaTrackable == null) metaTrackable = new MetaTrackable();
+            metaTrackable.setId((Integer) data.get(MT_ID));
+            metaTrackable.setName((String) data.get(MT_NAME));
+            metaTrackable.setTypeRaw((String) data.get(MT_TYPE));
+            metaTrackable.setCreatedAtRaw((Long) data.get(MT_CREATED_AT));
+            metaTrackable.setUpdatedAtRaw((Long) data.get(MT_UPDATED_AT));
+            metaTrackable.setCachedAtRaw((Long) data.get(MT_CACHED_AT));
+        }
     }
 }

--- a/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/TrackableType.java
+++ b/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/EndPoints/CheckIns/TrackableType.java
@@ -4,6 +4,8 @@ import com.flaredown.flaredownApp.R;
 
 import java.io.Serializable;
 
+import io.realm.RealmObject;
+
 /**
  * The type of trackable.
  */

--- a/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/Helper/Date.java
+++ b/App/app/src/main/java/com/flaredown/flaredownApp/Helpers/APIv2/Helper/Date.java
@@ -44,6 +44,42 @@ public class Date {
     }
 
     /**
+     * Get the time in millis from a string representation of a date.
+     * @param date The string representation of a date.
+     * @param format The format of the date given.
+     * @return The time in milliseconds.... Note returns null if error occurs.
+     */
+    @Nullable
+    public static Long stringToMillis(@Nullable String date, @NonNull SimpleDateFormat format) {
+        Calendar calendar = stringToCalendar(date, format);
+        if(calendar != null)
+            return calendar.getTimeInMillis();
+        return null;
+    }
+
+    /**
+     * Get the time in millis from a string representation of a date (In the API_DATE_FORMAT).
+     * @param date The string representation of a date (In the API_DATE_FORMAT).
+     * @return The time in milliseconds.... Note returns null if error occurs.
+     */
+    @Nullable
+    public static Long stringToMillis(@Nullable String date) {
+        return stringToMillis(date, API_DATE_FORMAT);
+    }
+
+    /**
+     * Creates a calendar instance from a millisecond time stamp.
+     * @param millis The time in millisecond values.
+     * @return New calendar object set to the millis given.
+     */
+    public static Calendar millisToCalendar(@Nullable Long millis) {
+        if(millis == null) return null;
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(millis);
+        return calendar;
+    }
+
+    /**
      * Formats the Calendar object passed into a string in the API date format.
      * @param date The date to be parsed.
      * @return The string fro the date... Note if null date then null will be returned.

--- a/App/build.gradle
+++ b/App/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The MetaTrackable Object is now stored in the Realm database for up to 14 days... After 14 days the object is removed from the database and will have to be re-downloaded.

The aim is to reduce the number of queries to the API, reducing strain on the server and reducing load times, especially for navigating between dates.
